### PR TITLE
style(README): returning relative link workflows Note section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > [!NOTE]
 > Currently there are 14 _GitHub Actions_
-> [workflows](https://github.com/szepeviktor/byte-level-care/blob/master/.github/workflows)
+> [workflows](.github/workflows)
 > in the repository.
 
 How to live with zero problems through Total Control.


### PR DESCRIPTION
Currently the [markdown](https://github.com/orgs/community/discussions/16925) has support for relative link.