### PR TITLE
Bump rhysd/actionlint

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -72,6 +72,6 @@ jobs:
             uses: "actions/checkout@v4.1.5"
         -
             name: "Analyze workflow files"
-            uses: "docker://rhysd/actionlint:1.7.1"
+            uses: "docker://rhysd/actionlint:1.7.3"
             with:
                 args: "-color -verbose -shellcheck="


### PR DESCRIPTION
Dependabot

> references to Docker container actions using docker:// syntax aren't supported.